### PR TITLE
Add content for the Fourth year undergraduate courses

### DIFF
--- a/content/courses/cmpe425.en.md
+++ b/content/courses/cmpe425.en.md
@@ -7,9 +7,38 @@ aliases:
   - undergraduate/courses/cmpe425
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE425 |
+| Course Title | Compiler Design |
+| Language of Instruction | English |
+| Course Semester | Spring |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | CMPE 260 and Consent |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
 ## Catalog Description
 
+Overview of the compilation process. Lexical analysis, regular expressions, finite automata and lexical analyzer generators. Symbol tables. Grammars. Top-down and bottom-up syntax analysis. Recursive-descent. SLR, canonical LR, LALR and operator precedence parsing techniques. Parser generators. Semantic analysis and attribute grammers. Abstract machines ad intermediate code. Syntax directed translation schemes. Implementation of a compiler for a simple imperative language.
+
 ## Course Learning Outcome
+
+- Understand the process of compilation and the components of a compiler
+- Comprehend the relationship between high-level programming languages and their realization as machine instructions
+- Gain knowledge of lexical analysis and parsing, along with their implementation strategies
+- Acquire the skills to design and implement compilers for simple imperative languages
+- Utilize tools such as lex, yacc, and LLVM in the construction of compilers
 
 ## Current Instructor
 

--- a/content/courses/cmpe425.en.md
+++ b/content/courses/cmpe425.en.md
@@ -34,11 +34,11 @@ Overview of the compilation process. Lexical analysis, regular expressions, fini
 
 ## Course Learning Outcome
 
-- Understand the process of compilation and the components of a compiler
-- Comprehend the relationship between high-level programming languages and their realization as machine instructions
-- Gain knowledge of lexical analysis and parsing, along with their implementation strategies
-- Acquire the skills to design and implement compilers for simple imperative languages
-- Utilize tools such as lex, yacc, and LLVM in the construction of compilers
+- Introduce process of compilation, components of a compiler
+- Establish the relationship between the program written in high level language and its realization as a sequence of machine instructions
+- Introduce the concepts of lexical analysis and parsing and their implementation strategies
+- Enable the student to design and implement compilers for simple languages
+- Enable the student to use compiler construction tools lex, yacc and LLVM
 
 ## Current Instructor
 

--- a/content/courses/cmpe425.en.md
+++ b/content/courses/cmpe425.en.md
@@ -7,6 +7,7 @@ aliases:
   - undergraduate/courses/cmpe425
 ---
 
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe425.en.md
+++ b/content/courses/cmpe425.en.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe425
 ---
 
-{{< warning >}}
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe425.en.md
+++ b/content/courses/cmpe425.en.md
@@ -22,7 +22,7 @@ aliases:
 | Course Credits | 3 |
 | ECTS | 6 |
 | Grading Mode | Letter Grade |
-| Prerequisites | CMPE 260 and Consent |
+| Prerequisites | CMPE 260 |
 | Corequisites | None |
 
 {{< /table >}}

--- a/content/courses/cmpe425.tr.md
+++ b/content/courses/cmpe425.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe425
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe425.tr.md
+++ b/content/courses/cmpe425.tr.md
@@ -23,7 +23,7 @@ aliases:
 | Ders Kredisi | 3 |
 | AKTS | 6 |
 | Notlandırma Sistemi | Harf Notu |
-| Önkoşul dersleri | CMPE 260 ve Egitmen Kabulu |
+| Önkoşul dersleri | CMPE 260 |
 | Eşkoşul dersleri | Yok |
 
 {{< /table >}}

--- a/content/courses/cmpe425.tr.md
+++ b/content/courses/cmpe425.tr.md
@@ -1,0 +1,50 @@
+---
+title: CMPE425
+description: Derleyici Tasarımı
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe425/1400
+aliases:
+  - undergraduate/courses/cmpe425
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE425 |
+| Ders Başlığı | Derleyici Tasarımı |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Bahar |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE 260 ve Egitmen Kabulu |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Derleme sürecine genel bakış. Sözcüksel analiz, düzenli ifadeler, sonlu otomatlar ve sözcüksel analizör üreteçleri. Sembol tabloları. Gramerler. Yukarıdan aşağıya ve aşağıdan yukarıya sözdizimi analizi. Özyinelemeli iniş. SLR, kanonik LR, LALR ve operatör önceliği ayrıştırma teknikleri. Ayrıştırıcı üreteçleri. Anlamsal analiz ve öznitelik gramerleri. Soyut makineler ve ara kod. Sözdizimine yönelik çeviri şemaları. Basit bir emir dili için bir derleyici uygulaması.
+
+## Dersin Öğrenme Çıktıları
+
+- Derleme sürecini ve bir derleyicinin bileşenlerini anlamak
+- Üst düzey programlama dilleri ile bunların makine komutları olarak gerçekleştirilmesi arasındaki ilişkiyi kavrayabilme
+- Sözcük analizi ve ayrıştırma ile bunların uygulama stratejileri hakkında bilgi edinme
+- Basit zorunlu diller için derleyici tasarlama ve uygulama becerileri edinme
+- Derleyicilerin oluşturulmasında lex, yacc ve LLVM gibi araçlardan yararlanma
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe425" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe425" cols="3">}}

--- a/content/courses/cmpe425.tr.md
+++ b/content/courses/cmpe425.tr.md
@@ -35,11 +35,11 @@ Derleme sürecine genel bakış. Sözcüksel analiz, düzenli ifadeler, sonlu ot
 
 ## Dersin Öğrenme Çıktıları
 
-- Derleme sürecini ve bir derleyicinin bileşenlerini anlamak
-- Üst düzey programlama dilleri ile bunların makine komutları olarak gerçekleştirilmesi arasındaki ilişkiyi kavrayabilme
-- Sözcük analizi ve ayrıştırma ile bunların uygulama stratejileri hakkında bilgi edinme
-- Basit zorunlu diller için derleyici tasarlama ve uygulama becerileri edinme
-- Derleyicilerin oluşturulmasında lex, yacc ve LLVM gibi araçlardan yararlanma
+- Derleme sürecini, derleyicinin bileşenlerini tanıtmak
+- Yüksek seviyeli dilde yazılan program ile bunun makine talimatları dizisi olarak gerçekleştirilmesi arasındaki ilişkinin kurulması
+- Sözcük analizi ve ayrıştırma kavramlarını ve bunların uygulama stratejilerini tanıtmak
+- Öğrencinin basit diller için derleyici tasarlamasını ve uygulamasını sağlamak
+- Öğrencinin lex, yacc ve LLVM derleyici oluşturma araçlarını kullanmasını sağlamak
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe425.tr.md
+++ b/content/courses/cmpe425.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe425
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe434.en.md
+++ b/content/courses/cmpe434.en.md
@@ -22,7 +22,7 @@ aliases:
 | Course Credits | 3 |
 | ECTS | 6 |
 | Grading Mode | Letter Grade |
-| Prerequisites | Programming Experience in C++ or Python and Familiarity with Linux-based systems |
+| Prerequisites | None |
 | Corequisites | None |
 
 {{< /table >}}

--- a/content/courses/cmpe434.en.md
+++ b/content/courses/cmpe434.en.md
@@ -7,6 +7,7 @@ aliases:
   - undergraduate/courses/cmpe434
 ---
 
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->
@@ -31,6 +32,7 @@ aliases:
 ## Catalog Description
 
 Designing, building and programming mobile robots; sensors, effectors, locomotion, basic control theory, control architectures, path planning, localization, mapping, learning. Teamwork; robot contest.
+
 
 
 ## Current Instructor

--- a/content/courses/cmpe434.en.md
+++ b/content/courses/cmpe434.en.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe434
 ---
 
-{{< warning >}}
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe434.en.md
+++ b/content/courses/cmpe434.en.md
@@ -7,9 +7,40 @@ aliases:
   - undergraduate/courses/cmpe434
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE434 |
+| Course Title | Introduction to Robotics |
+| Language of Instruction | English |
+| Course Semester | Spring |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | Programming Experience in C++ or Python and Familiarity with Linux-based systems |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
 ## Catalog Description
 
-## Course Learning Outcome
+Designing, building and programming mobile robots; sensors, effectors, locomotion, basic control theory, control architectures, path planning, localization, mapping, learning. Teamwork; robot contest.
+
+## Course Learning Outcomes
+
+- Understand the fundamental principles of mobile robotics, including control and navigation techniques
+- Gain proficiency in designing, building, and programming mobile robots using sensors, effectors, and locomotion mechanisms
+- Apply basic control theory and control architectures in robotic systems
+- Develop skills in path planning, localization, and mapping for autonomous mobile robots
+- Explore and implement strategies for robot learning and adaptation
+- Collaborate in teams to design and compete in a robot contest
+- Utilize simulation tools to test and evaluate control and navigation strategies for mobile robots
 
 ## Current Instructor
 

--- a/content/courses/cmpe434.en.md
+++ b/content/courses/cmpe434.en.md
@@ -32,15 +32,6 @@ aliases:
 
 Designing, building and programming mobile robots; sensors, effectors, locomotion, basic control theory, control architectures, path planning, localization, mapping, learning. Teamwork; robot contest.
 
-## Course Learning Outcomes
-
-- Understand the fundamental principles of mobile robotics, including control and navigation techniques
-- Gain proficiency in designing, building, and programming mobile robots using sensors, effectors, and locomotion mechanisms
-- Apply basic control theory and control architectures in robotic systems
-- Develop skills in path planning, localization, and mapping for autonomous mobile robots
-- Explore and implement strategies for robot learning and adaptation
-- Collaborate in teams to design and compete in a robot contest
-- Utilize simulation tools to test and evaluate control and navigation strategies for mobile robots
 
 ## Current Instructor
 

--- a/content/courses/cmpe434.tr.md
+++ b/content/courses/cmpe434.tr.md
@@ -23,7 +23,7 @@ aliases:
 | Ders Kredisi | 3 |
 | AKTS | 6 |
 | Notlandırma Sistemi | Harf Notu |
-| Önkoşul dersleri | C++ veya Python'da Programlama Deneyimi ve Linux tabanlı sistemlere aşinalık |
+| Önkoşul dersleri | Yok |
 | Eşkoşul dersleri | Yok |
 
 {{< /table >}}

--- a/content/courses/cmpe434.tr.md
+++ b/content/courses/cmpe434.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe434
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe434.tr.md
+++ b/content/courses/cmpe434.tr.md
@@ -33,15 +33,6 @@ aliases:
 
 Mobil robotların tasarlanması, inşa edilmesi ve programlanması; sensörler, efektörler, hareket, temel kontrol teorisi, kontrol mimarileri, yol planlama, lokalizasyon, haritalama, öğrenme. Takım çalışması; robot yarışması.
 
-## Dersin Öğrenme Çıktıları
-
-- Kontrol ve navigasyon teknikleri de dahil olmak üzere mobil robotiğin temel ilkelerini anlamak
-- Sensörler, efektörler ve hareket mekanizmaları kullanarak mobil robotlar tasarlama, inşa etme ve programlama konusunda yetkinlik kazanma
-- Temel kontrol teorisini ve kontrol mimarilerini robotik sistemlere uygulayabilme
-- Otonom mobil robotlar için yol planlama, lokalizasyon ve haritalama becerilerinin geliştirilmesi
-- Robot öğrenimi ve adaptasyonu için stratejileri keşfetmek ve uygulamak
-- Bir robot yarışması tasarlamak ve yarışmak için ekipler halinde işbirliği yapmak
-- Mobil robotlar için kontrol ve navigasyon stratejilerini test etmek ve değerlendirmek için simülasyon araçlarını kullanma
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe434.tr.md
+++ b/content/courses/cmpe434.tr.md
@@ -1,0 +1,52 @@
+---
+title: CMPE434
+description: Robotbilime Giriş
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe434/1400
+aliases:
+  - undergraduate/courses/cmpe434
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE434 |
+| Ders Başlığı | Robotbilime Giriş |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Bahar |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | C++ veya Python'da Programlama Deneyimi ve Linux tabanlı sistemlere aşinalık |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Mobil robotların tasarlanması, inşa edilmesi ve programlanması; sensörler, efektörler, hareket, temel kontrol teorisi, kontrol mimarileri, yol planlama, lokalizasyon, haritalama, öğrenme. Takım çalışması; robot yarışması.
+
+## Dersin Öğrenme Çıktıları
+
+- Kontrol ve navigasyon teknikleri de dahil olmak üzere mobil robotiğin temel ilkelerini anlamak
+- Sensörler, efektörler ve hareket mekanizmaları kullanarak mobil robotlar tasarlama, inşa etme ve programlama konusunda yetkinlik kazanma
+- Temel kontrol teorisini ve kontrol mimarilerini robotik sistemlere uygulayabilme
+- Otonom mobil robotlar için yol planlama, lokalizasyon ve haritalama becerilerinin geliştirilmesi
+- Robot öğrenimi ve adaptasyonu için stratejileri keşfetmek ve uygulamak
+- Bir robot yarışması tasarlamak ve yarışmak için ekipler halinde işbirliği yapmak
+- Mobil robotlar için kontrol ve navigasyon stratejilerini test etmek ve değerlendirmek için simülasyon araçlarını kullanma
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe434" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe434" cols="3">}}

--- a/content/courses/cmpe434.tr.md
+++ b/content/courses/cmpe434.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe434
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe443.en.md
+++ b/content/courses/cmpe443.en.md
@@ -34,12 +34,10 @@ Embedded systems design flow. Hardware-software co-design. Real-time software de
 
 ## Course Learning Outcomes
 
-- Understand the fundamental principles and design flow of embedded systems
-- Gain knowledge of hardware-software co-design techniques for embedded systems
-- Develop skills in real-time software design and real-time debugging techniques using relevant tools
-- Design and integrate hardware and software components through interface design for embedded systems
-- Implement and analyze embedded systems in data acquisition and control applications
-- Apply practical knowledge in the laboratory through hands-on experience in embedded system design
+- Differentiate an embedded computing system from a general-purpose computing system.
+- Design an embedded system by using software and hardware components.
+- Apply embedded software design techniques to interact with the sensors, actors, and other devices.
+- Explain and implement timed behavior.
 
 ## Current Instructor
 

--- a/content/courses/cmpe443.en.md
+++ b/content/courses/cmpe443.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe443/1400
 aliases:
   - undergraduate/courses/cmpe443
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe443.en.md
+++ b/content/courses/cmpe443.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe443/1400
 aliases:
   - undergraduate/courses/cmpe443
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe443.en.md
+++ b/content/courses/cmpe443.en.md
@@ -7,9 +7,39 @@ aliases:
   - undergraduate/courses/cmpe443
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE443 |
+| Course Title | Principles of Embedded Systems Design |
+| Language of Instruction | English |
+| Course Semester | Fall |
+| Course Hours | Lecture: 3, PS:1, Labs: 2 |
+| Course Credits | 4 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | CMPE240 |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
 ## Catalog Description
 
-## Course Learning Outcome
+Embedded systems design flow. Hardware-software co-design. Real-time software design. Real-time debugging techniques and tools. Hardware-software integration: interface design. Examples on the design of data acquisition and control systems. Laboratory.
+
+## Course Learning Outcomes
+
+- Understand the fundamental principles and design flow of embedded systems
+- Gain knowledge of hardware-software co-design techniques for embedded systems
+- Develop skills in real-time software design and real-time debugging techniques using relevant tools
+- Design and integrate hardware and software components through interface design for embedded systems
+- Implement and analyze embedded systems in data acquisition and control applications
+- Apply practical knowledge in the laboratory through hands-on experience in embedded system design
 
 ## Current Instructor
 

--- a/content/courses/cmpe443.tr.md
+++ b/content/courses/cmpe443.tr.md
@@ -35,12 +35,10 @@ Gömülü sistem tasarım akışı. Donanım-yazılım ortak tasarımı. Gerçek
 
 ## Dersin Öğrenme Çıktıları
 
-- Gömülü sistemlerin temel prensiplerini ve tasarım akışını anlamak
-- Gömülü sistemler için donanım-yazılım ortak tasarım teknikleri hakkında bilgi edinme
-- İlgili araçları kullanarak gerçek zamanlı yazılım tasarımı ve gerçek zamanlı hata ayıklama teknikleri konusunda beceriler geliştirmek
-- Gömülü sistemler için arayüz tasarımı yoluyla donanım ve yazılım bileşenlerini tasarlama ve entegre etme
-- Veri toplama ve kontrol uygulamalarında gömülü sistemlerin uygulanması ve analizi
-- Gömülü sistem tasarımında uygulamalı deneyim yoluyla laboratuvarda pratik bilgileri uygulama
+- Gömülü bir bilgi işlem sistemini genel amaçlı bir bilgi işlem sisteminden ayırt edebilme.
+- Yazılım ve donanım bileşenlerini kullanarak gömülü bir sistem tasarlayabilecektir.
+- Sensörler, aktörler ve diğer cihazlarla etkileşim için gömülü yazılım tasarım tekniklerini uygulama.
+- Zamanlanmış davranışı açıklamak ve uygulamak.
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe443.tr.md
+++ b/content/courses/cmpe443.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe443
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe443.tr.md
+++ b/content/courses/cmpe443.tr.md
@@ -1,0 +1,51 @@
+---
+title: CMPE443
+description: Gömülü Sistem Tasarım Temelleri
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe443/1400
+aliases:
+  - undergraduate/courses/cmpe443
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE443 |
+| Ders Başlığı | Gömülü Sistem Tasarım Temelleri |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Güz |
+| Ders Saatleri | Ders: 3, PS:1, Laboratuvar:2 |
+| Ders Kredisi | 4 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE240 |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Gömülü sistem tasarım akışı. Donanım-yazılım ortak tasarımı. Gerçek zamanlı yazılım tasarımı. Gerçek zamanlı hata ayıklama teknikleri ve araçları. Donanım-yazılım entegrasyonu: arayüz tasarımı. Veri toplama ve kontrol sistemlerinin tasarımı üzerine örnekler. Laboratuvar.
+
+## Dersin Öğrenme Çıktıları
+
+- Gömülü sistemlerin temel prensiplerini ve tasarım akışını anlamak
+- Gömülü sistemler için donanım-yazılım ortak tasarım teknikleri hakkında bilgi edinme
+- İlgili araçları kullanarak gerçek zamanlı yazılım tasarımı ve gerçek zamanlı hata ayıklama teknikleri konusunda beceriler geliştirmek
+- Gömülü sistemler için arayüz tasarımı yoluyla donanım ve yazılım bileşenlerini tasarlama ve entegre etme
+- Veri toplama ve kontrol uygulamalarında gömülü sistemlerin uygulanması ve analizi
+- Gömülü sistem tasarımında uygulamalı deneyim yoluyla laboratuvarda pratik bilgileri uygulama
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe443" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe443" cols="3">}}

--- a/content/courses/cmpe443.tr.md
+++ b/content/courses/cmpe443.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe443
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe446.en.md
+++ b/content/courses/cmpe446.en.md
@@ -32,15 +32,6 @@ aliases:
 
 Performance limits of Von Neumann architecture. Reduced Instruction Set Computer (RISC) architecture. Pipelined processor design. Instruction pipeline and arithmetic pipelines. Array processors. Dynamic and static interconnection networks. Shared memory multiprocessor systems. Message passing multiprocessor systems.
 
-## Course Learning Outcomes
-
-- Understand the performance limits and challenges of the Von Neumann architecture
-- Gain knowledge of Reduced Instruction Set Computer (RISC) architecture and its design principles
-- Analyze and design pipelined processors, including instruction and arithmetic pipelines
-- Explore array processors and their applications in high-performance computing
-- Comprehend the design and operation of dynamic and static interconnection networks in multiprocessor systems
-- Understand the architecture of shared memory multiprocessor systems and message-passing multiprocessor systems
-- Apply principles of computer architecture in solving performance and design issues for modern processors
 
 
 ## Current Instructor

--- a/content/courses/cmpe446.en.md
+++ b/content/courses/cmpe446.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe446/1400
 aliases:
   - undergraduate/courses/cmpe446
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe446.en.md
+++ b/content/courses/cmpe446.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe446/1400
 aliases:
   - undergraduate/courses/cmpe446
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe446.en.md
+++ b/content/courses/cmpe446.en.md
@@ -7,9 +7,41 @@ aliases:
   - undergraduate/courses/cmpe446
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE446 |
+| Course Title | Introduction to Computer Architecture |
+| Language of Instruction | English |
+| Course Semester | Spring |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | CMPE344 and CMPE322 |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
 ## Catalog Description
 
-## Course Learning Outcome
+Performance limits of Von Neumann architecture. Reduced Instruction Set Computer (RISC) architecture. Pipelined processor design. Instruction pipeline and arithmetic pipelines. Array processors. Dynamic and static interconnection networks. Shared memory multiprocessor systems. Message passing multiprocessor systems.
+
+## Course Learning Outcomes
+
+- Understand the performance limits and challenges of the Von Neumann architecture
+- Gain knowledge of Reduced Instruction Set Computer (RISC) architecture and its design principles
+- Analyze and design pipelined processors, including instruction and arithmetic pipelines
+- Explore array processors and their applications in high-performance computing
+- Comprehend the design and operation of dynamic and static interconnection networks in multiprocessor systems
+- Understand the architecture of shared memory multiprocessor systems and message-passing multiprocessor systems
+- Apply principles of computer architecture in solving performance and design issues for modern processors
+
 
 ## Current Instructor
 

--- a/content/courses/cmpe446.tr.md
+++ b/content/courses/cmpe446.tr.md
@@ -1,0 +1,52 @@
+---
+title: CMPE446
+description: Bilgisayar Mimarisine Giriş
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe446/1400
+aliases:
+  - undergraduate/courses/cmpe446
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE446 |
+| Ders Başlığı | Bilgisayar Mimarisine Giriş |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Bahar |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE344 ve CMPE322  |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Von Neumann mimarisinin performans sınırları. Azaltılmış Komut Kümeli Bilgisayar (RISC) mimarisi. Pipelined işlemci tasarımı. Komut boru hattı ve aritmetik boru hatları. Dizi işlemciler. Dinamik ve statik ara bağlantı ağları. Paylaşımlı bellek çoklu işlemci sistemleri. Mesaj geçiren çoklu işlemci sistemleri.
+
+## Dersin Öğrenme Çıktıları
+
+- Von Neumann mimarisinin performans sınırlarını ve zorluklarını anlama
+- Azaltılmış Komut Kümeli Bilgisayar (RISC) mimarisi ve tasarım ilkeleri hakkında bilgi edinme
+- Komut ve aritmetik işlem hatları dahil olmak üzere boru hatlı işlemcileri analiz etme ve tasarlama
+- Dizi işlemcileri ve bunların yüksek performanslı hesaplamadaki uygulamalarını keşfedin
+- Çok işlemcili sistemlerde dinamik ve statik ara bağlantı ağlarının tasarımını ve işleyişini kavrayabilme
+- Paylaşımlı bellek çoklu işlemci sistemlerinin ve mesaj geçiren çoklu işlemci sistemlerinin mimarisini anlamak
+- Modern işlemciler için performans ve tasarım sorunlarını çözmede bilgisayar mimarisi ilkelerini uygulama
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe446" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe446" cols="3">}}

--- a/content/courses/cmpe446.tr.md
+++ b/content/courses/cmpe446.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe446
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe446.tr.md
+++ b/content/courses/cmpe446.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe446
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe446.tr.md
+++ b/content/courses/cmpe446.tr.md
@@ -33,16 +33,6 @@ aliases:
 
 Von Neumann mimarisinin performans sınırları. Azaltılmış Komut Kümeli Bilgisayar (RISC) mimarisi. Pipelined işlemci tasarımı. Komut boru hattı ve aritmetik boru hatları. Dizi işlemciler. Dinamik ve statik ara bağlantı ağları. Paylaşımlı bellek çoklu işlemci sistemleri. Mesaj geçiren çoklu işlemci sistemleri.
 
-## Dersin Öğrenme Çıktıları
-
-- Von Neumann mimarisinin performans sınırlarını ve zorluklarını anlama
-- Azaltılmış Komut Kümeli Bilgisayar (RISC) mimarisi ve tasarım ilkeleri hakkında bilgi edinme
-- Komut ve aritmetik işlem hatları dahil olmak üzere boru hatlı işlemcileri analiz etme ve tasarlama
-- Dizi işlemcileri ve bunların yüksek performanslı hesaplamadaki uygulamalarını keşfedin
-- Çok işlemcili sistemlerde dinamik ve statik ara bağlantı ağlarının tasarımını ve işleyişini kavrayabilme
-- Paylaşımlı bellek çoklu işlemci sistemlerinin ve mesaj geçiren çoklu işlemci sistemlerinin mimarisini anlamak
-- Modern işlemciler için performans ve tasarım sorunlarını çözmede bilgisayar mimarisi ilkelerini uygulama
-
 ## Dersi Veren Öğretim Üyesi
 
 {{< people tag="cmpe446" cols="2">}}

--- a/content/courses/cmpe451.en.md
+++ b/content/courses/cmpe451.en.md
@@ -36,11 +36,12 @@ Management and implementation of a large software development as a group. Applic
 ## Course Learning Outcome
 
 - To experience the application of software development techniques and methodologies throughout various stages of the software development lifecycle including planning, requirements gathering, design, implementation, testing, deployment, and delivery.
-- To acquire team-based software development skills such as communication, planning, and time-management.
+- To acquire team-based software development skills such as communication, planning, and
+time management.
 - To gain communication skills required to interact with customers and the project team members.
 - To develop skills in planning and managing software development projects.
 - To gain the ability to use software development tools, techniques, environments, and methodologies for effective and productive software development.
-- To apply various Computer Engineering knowledge and algorithms, as learnt in earlier courses, to software development.
+- To apply various Computer Engineering knowledge and algorithms, as learned in earlier courses, to software development.
 
 ## Current Instructor
 

--- a/content/courses/cmpe451.en.md
+++ b/content/courses/cmpe451.en.md
@@ -7,9 +7,40 @@ aliases:
   - undergraduate/courses/cmpe451
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE451 |
+| Course Title | Project Development in Software Engineering |
+| Language of Instruction | English |
+| Course Semester | Fall |
+| Course Hours | Lecture: 1, PS:0, Labs: 2 |
+| Course Credits | 2 |
+| ECTS | 5 |
+| Grading Mode | Letter Grade |
+| Prerequisites | CMPE352 and CMPE321 |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
 
+Management and implementation of a large software development as a group. Application of software engineering principles in a project setting.
+
 ## Course Learning Outcome
+
+- To experience the application of software development techniques and methodologies throughout various stages of the software development lifecycle including planning, requirements gathering, design, implementation, testing, deployment, and delivery.
+- To acquire team-based software development skills such as communication, planning, and time-management.
+- To gain communication skills required to interact with customers and the project team members.
+- To develop skills in planning and managing software development projects.
+- To gain the ability to use software development tools, techniques, environments, and methodologies for effective and productive software development.
+- To apply various Computer Engineering knowledge and algorithms, as learnt in earlier courses, to software development.
 
 ## Current Instructor
 

--- a/content/courses/cmpe451.en.md
+++ b/content/courses/cmpe451.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe451/1400
 aliases:
   - undergraduate/courses/cmpe451
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe451.en.md
+++ b/content/courses/cmpe451.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe451/1400
 aliases:
   - undergraduate/courses/cmpe451
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe451.tr.md
+++ b/content/courses/cmpe451.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe451
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe451.tr.md
+++ b/content/courses/cmpe451.tr.md
@@ -1,0 +1,51 @@
+---
+title: CMPE451
+description: Yazılım Mühendisliği'nde Proje Tasarımı
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe451/1400
+aliases:
+  - undergraduate/courses/cmpe451
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE451 |
+| Ders Başlığı | Yazılım Mühendisliği'nde Proje Tasarımı |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Güz |
+| Ders Saatleri | Ders: 1, PS:0, Laboratuvar:2 |
+| Ders Kredisi | 2 |
+| AKTS | 5 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE352 ve CMPE321  |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Grup olarak büyük bir yazılım geliştirmenin yönetimi ve uygulanması. Yazılım mühendisliği ilkelerinin bir proje ortamında uygulanması.
+
+## Dersin Öğrenme Çıktıları
+
+- Planlama, gereksinim toplama, tasarım, uygulama, test etme, dağıtım ve teslimat dahil olmak üzere yazılım geliştirme yaşam döngüsünün çeşitli aşamalarında yazılım geliştirme tekniklerinin ve metodolojilerinin uygulanmasını deneyimlemek.
+- İletişim, planlama ve zaman yönetimi gibi ekip tabanlı yazılım geliştirme becerileri edinmek.
+- Müşteriler ve proje ekibi üyeleri ile etkileşim için gerekli iletişim becerilerini kazanmak.
+- Yazılım geliştirme projelerini planlama ve yönetme becerilerini geliştirmek.
+- Etkin ve verimli yazılım geliştirme için yazılım geliştirme araçlarını, tekniklerini, ortamlarını ve metodolojilerini kullanma becerisi kazanmak.
+- Daha önceki derslerde öğrenilen çeşitli Bilgisayar Mühendisliği bilgilerini ve algoritmalarını yazılım geliştirmeye uygulamak.
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe451" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe451" cols="3">}}

--- a/content/courses/cmpe451.tr.md
+++ b/content/courses/cmpe451.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe451
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe451.tr.md
+++ b/content/courses/cmpe451.tr.md
@@ -35,12 +35,13 @@ Grup olarak büyük bir yazılım geliştirmenin yönetimi ve uygulanması. Yaz�
 
 ## Dersin Öğrenme Çıktıları
 
-- Planlama, gereksinim toplama, tasarım, uygulama, test etme, dağıtım ve teslimat dahil olmak üzere yazılım geliştirme yaşam döngüsünün çeşitli aşamalarında yazılım geliştirme tekniklerinin ve metodolojilerinin uygulanmasını deneyimlemek.
-- İletişim, planlama ve zaman yönetimi gibi ekip tabanlı yazılım geliştirme becerileri edinmek.
+- Yazılım geliştirme tekniklerinin ve metodolojilerinin, planlama, gereksinimler ve yazılım geliştirme yaşam döngüsünün çeşitli aşamalarında uygulanmasını deneyimlemek toplama, tasarım, uygulama, test etme, dağıtım ve teslimat.
+- İletişim, planlama ve koordinasyon gibi takım tabanlı yazılım geliştirme becerilerini edinmek.
+Zaman yönetimi.
 - Müşteriler ve proje ekibi üyeleri ile etkileşim için gerekli iletişim becerilerini kazanmak.
 - Yazılım geliştirme projelerini planlama ve yönetme becerilerini geliştirmek.
 - Etkin ve verimli yazılım geliştirme için yazılım geliştirme araçlarını, tekniklerini, ortamlarını ve metodolojilerini kullanma becerisi kazanmak.
-- Daha önceki derslerde öğrenilen çeşitli Bilgisayar Mühendisliği bilgilerini ve algoritmalarını yazılım geliştirmeye uygulamak.
+- Daha önceki derslerde öğrenilen çeşitli Bilgisayar Mühendisliği bilgilerini ve algoritmalarını uygulamak. kurslar, yazılım geliştirme.
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe460.en.md
+++ b/content/courses/cmpe460.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe460/1400
 aliases:
   - undergraduate/courses/cmpe460
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe460.en.md
+++ b/content/courses/cmpe460.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe460/1400
 aliases:
   - undergraduate/courses/cmpe460
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe460.en.md
+++ b/content/courses/cmpe460.en.md
@@ -7,9 +7,39 @@ aliases:
   - undergraduate/courses/cmpe460
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE460 |
+| Course Title | Introduction to Computer Graphics|
+| Language of Instruction | English |
+| Course Semester | Spring |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | None |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
 
+Computer Graphics deals with the synthesis of images from geometric models and textures; which may be acquired form the real world or may be synthetically generated as well. The course will focus on modeling; which is the geometric description of 3D scenes; and rendering, which creates realistic images from such models.  An important component of the course is the use of mathematics. The course uses linear algebra, and other areas of math. We will review mathematical basics used in the course. Programming experience in C++ and a basic knowledge of calculus and linear algebra is assumed. Apart from the lecture topics listed below, some OpenGL programming will also be covered.
+
 ## Course Learning Outcome
+
+- To understand the working of the rendering pipeline in a modern computer.
+- To apply linear algebra to model graphical primitives.
+- To design a ray tracer and implement it.
+- To understand the use of geometric models to represent curves and surfaces in 3D.
+- To understand more advanced rendering techniques.
 
 ## Current Instructor
 

--- a/content/courses/cmpe460.tr.md
+++ b/content/courses/cmpe460.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe460
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe460.tr.md
+++ b/content/courses/cmpe460.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe460
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe460.tr.md
+++ b/content/courses/cmpe460.tr.md
@@ -1,0 +1,50 @@
+---
+title: CMPE460
+description: Bilgisayar Grafiğine Giriş
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe460/1400
+aliases:
+  - undergraduate/courses/cmpe460
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE460 |
+| Ders Başlığı | Bilgisayar Grafiğine Giriş |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Bahar |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | Yok |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Bilgisayar Grafikleri, gerçek dünyadan elde edilebilen veya sentetik olarak da oluşturulabilen geometrik modellerden ve dokulardan görüntülerin sentezlenmesiyle ilgilenir. Ders, 3D sahnelerin geometrik tanımı olan modelleme ve bu modellerden gerçekçi görüntüler oluşturan render üzerine odaklanacaktır.  Dersin önemli bir bileşeni de matematik kullanımıdır. Derste lineer cebir ve matematiğin diğer alanları kullanılacaktır. Derste kullanılan matematiksel temelleri gözden geçireceğiz. C++ programlama deneyimi ve temel kalkülüs ve lineer cebir bilgisi varsayılmaktadır. Aşağıda listelenen ders konularının yanı sıra, bazı OpenGL programlama konuları da ele alınacaktır.
+
+## Dersin Öğrenme Çıktıları
+
+- Modern bir bilgisayardaki işleme hattının çalışmasını anlamak.
+- Grafiksel ilkelleri modellemek için doğrusal cebir uygulamak.
+- Bir ışın izleyici tasarlamak ve uygulamak.
+- 3D'de eğrileri ve yüzeyleri temsil etmek için geometrik modellerin kullanımını anlamak.
+- Daha gelişmiş render tekniklerini anlamak.
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe460" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe460" cols="3">}}

--- a/content/courses/cmpe462.en.md
+++ b/content/courses/cmpe462.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe462/1400
 aliases:
   - undergraduate/courses/cmpe462
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe462.en.md
+++ b/content/courses/cmpe462.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe462/1400
 aliases:
   - undergraduate/courses/cmpe462
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe462.en.md
+++ b/content/courses/cmpe462.en.md
@@ -35,9 +35,9 @@ Overview of artificial learning systems. Supervised and unsupervised learning. S
 
 ## Course Learning Outcomes
 
-- Acquire knowledge of basic machine learning methods, including algorithms like perceptron, linear regression, logistic regression, naive Bayes, decision trees, support vector machines, and neural networks
-- Implement prediction methods using both supervised and unsupervised learning techniques
-- Gain practical experience in analyzing real-world data sets and applying machine learning models
+- Knowledge of basic machine learning methods
+- Implementation of prediction methods
+- Experience with analysis of real data
 
 ## Current Instructor
 

--- a/content/courses/cmpe462.en.md
+++ b/content/courses/cmpe462.en.md
@@ -7,9 +7,37 @@ aliases:
   - undergraduate/courses/cmpe462
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE462 |
+| Course Title | Machine Learning |
+| Language of Instruction | English |
+| Course Semester | Fall |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | Consent |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
 
-## Course Learning Outcome
+Overview of artificial learning systems. Supervised and unsupervised learning. Statistical models. Decision trees. Clustering. Feature extraction. Artificial neural networks. Reinforcement learning. Applications to pattern recognition Overview of artificial learning systems. Supervised and unsupervised learning. Statistical models. Decision trees. Clustering. Feature extraction. Artificial neural networks. Reinforcement learning. Applications to pattern recognition and data mining.
+
+## Course Learning Outcomes
+
+- Acquire knowledge of basic machine learning methods, including algorithms like perceptron, linear regression, logistic regression, naive Bayes, decision trees, support vector machines, and neural networks
+- Implement prediction methods using both supervised and unsupervised learning techniques
+- Gain practical experience in analyzing real-world data sets and applying machine learning models
 
 ## Current Instructor
 

--- a/content/courses/cmpe462.en.md
+++ b/content/courses/cmpe462.en.md
@@ -22,7 +22,7 @@ aliases:
 | Course Credits | 3 |
 | ECTS | 6 |
 | Grading Mode | Letter Grade |
-| Prerequisites | Consent |
+| Prerequisites | None |
 | Corequisites | None |
 
 {{< /table >}}

--- a/content/courses/cmpe462.tr.md
+++ b/content/courses/cmpe462.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe462
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe462.tr.md
+++ b/content/courses/cmpe462.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe462
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe462.tr.md
+++ b/content/courses/cmpe462.tr.md
@@ -1,0 +1,48 @@
+---
+title: CMPE462
+description: Yapay Öğrenme
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe462/1400
+aliases:
+  - undergraduate/courses/cmpe462
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE462 |
+| Ders Başlığı | Yapay Öğrenme |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Güz |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | Yok |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Yapay öğrenme sistemlerine genel bakış. Denetimli ve denetimsiz öğrenme. İstatistiksel modeller. Karar ağaçları. Kümeleme. Özellik çıkarma. Yapay sinir ağları. Takviyeli öğrenme. Örüntü tanıma uygulamaları Yapay öğrenme sistemlerine genel bakış. Denetimli ve denetimsiz öğrenme. İstatistiksel modeller. Karar ağaçları. Kümeleme. Özellik çıkarma. Yapay sinir ağları. Takviyeli öğrenme. Örüntü tanıma ve veri madenciliği uygulamaları.
+
+## Dersin Öğrenme Çıktıları
+
+- Perceptron, doğrusal regresyon, lojistik regresyon, naive Bayes, karar ağaçları, destek vektör makineleri ve sinir ağları gibi algoritmalar dahil olmak üzere temel makine öğrenimi yöntemleri hakkında bilgi edinmek.
+- Hem denetimli hem de denetimsiz öğrenme tekniklerini kullanarak tahmin yöntemlerini uygulamak.
+- Gerçek dünya veri setlerini analiz etme ve makine öğrenimi modellerini uygulama konusunda pratik deneyim kazanınmı.
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe462" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe462" cols="3">}}

--- a/content/courses/cmpe462.tr.md
+++ b/content/courses/cmpe462.tr.md
@@ -35,9 +35,9 @@ Yapay öğrenme sistemlerine genel bakış. Denetimli ve denetimsiz öğrenme. �
 
 ## Dersin Öğrenme Çıktıları
 
-- Perceptron, doğrusal regresyon, lojistik regresyon, naive Bayes, karar ağaçları, destek vektör makineleri ve sinir ağları gibi algoritmalar dahil olmak üzere temel makine öğrenimi yöntemleri hakkında bilgi edinmek.
-- Hem denetimli hem de denetimsiz öğrenme tekniklerini kullanarak tahmin yöntemlerini uygulamak.
-- Gerçek dünya veri setlerini analiz etme ve makine öğrenimi modellerini uygulama konusunda pratik deneyim kazanınmı.
+- Temel makine öğrenimi yöntemleri hakkında bilgi
+- Tahmin yöntemlerinin uygulanması
+- Gerçek verilerin analizi konusunda deneyim
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe470.en.md
+++ b/content/courses/cmpe470.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe470/1400
 aliases:
   - undergraduate/courses/cmpe470
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe470.en.md
+++ b/content/courses/cmpe470.en.md
@@ -22,7 +22,7 @@ aliases:
 | Course Credits | 3 |
 | ECTS | 6 |
 | Grading Mode | Letter Grade |
-| Prerequisites | Senior in CMPE |
+| Prerequisites | None |
 | Corequisites | None |
 
 {{< /table >}}

--- a/content/courses/cmpe470.en.md
+++ b/content/courses/cmpe470.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe470/1400
 aliases:
   - undergraduate/courses/cmpe470
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe470.en.md
+++ b/content/courses/cmpe470.en.md
@@ -17,7 +17,7 @@ aliases:
 | Course Code | CMPE470 |
 | Course Title | Computer Performance Evaluation |
 | Language of Instruction | English |
-| Course Semester | -- |
+| Course Semester | Not Avaliable at the moment |
 | Course Hours | Lecture: 3, PS:0, Labs: 0 |
 | Course Credits | 3 |
 | ECTS | 6 |
@@ -33,14 +33,6 @@ aliases:
 
 Nature of computer performance evaluation. Job processing models. Analytical techniques. Simulation. Management and control of system hardware and software resources. Performance of multiprocessing systems.
 
-## Course Learning Outcomes
-
-- Understand the fundamental principles and methodologies for evaluating computer system performance
-- Apply job processing models and analytical techniques to assess system efficiency and throughput
-- Develop proficiency in simulation techniques for performance analysis of computer systems
-- Manage and control system hardware and software resources for optimal performance
-- Analyze and evaluate the performance of multiprocessing systems in various operational environments
-- Utilize appropriate tools and techniques to model and predict the performance of complex computer systems
 
 ## Current Instructor
 

--- a/content/courses/cmpe470.en.md
+++ b/content/courses/cmpe470.en.md
@@ -7,9 +7,40 @@ aliases:
   - undergraduate/courses/cmpe470
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE470 |
+| Course Title | Computer Performance Evaluation |
+| Language of Instruction | English |
+| Course Semester | -- |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | Senior in CMPE |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
 
-## Course Learning Outcome
+Nature of computer performance evaluation. Job processing models. Analytical techniques. Simulation. Management and control of system hardware and software resources. Performance of multiprocessing systems.
+
+## Course Learning Outcomes
+
+- Understand the fundamental principles and methodologies for evaluating computer system performance
+- Apply job processing models and analytical techniques to assess system efficiency and throughput
+- Develop proficiency in simulation techniques for performance analysis of computer systems
+- Manage and control system hardware and software resources for optimal performance
+- Analyze and evaluate the performance of multiprocessing systems in various operational environments
+- Utilize appropriate tools and techniques to model and predict the performance of complex computer systems
 
 ## Current Instructor
 

--- a/content/courses/cmpe470.tr.md
+++ b/content/courses/cmpe470.tr.md
@@ -18,7 +18,7 @@ aliases:
 | Ders Kodu | CMPE470 |
 | Ders Başlığı | Bilgisayar Performansı Değerlendirmesi |
 | Öğretim Dili | İngilizce |
-| Ders Dönemi | -- |
+| Ders Dönemi | Şu anda mevcut değil |
 | Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
 | Ders Kredisi | 3 |
 | AKTS | 6 |
@@ -32,15 +32,6 @@ aliases:
 ## Katalog Tanımı
 
 Bilgisayar performans değerlendirmesinin doğası. İş işleme modelleri. Analitik teknikler. Simülasyon. Sistem donanım ve yazılım kaynaklarının yönetimi ve kontrolü. Çok işlemli sistemlerin performansı.
-
-## Dersin Öğrenme Çıktıları
-
-- Bilgisayar sistem performansını değerlendirmeye yönelik temel ilke ve metodolojileri anlamak.
-- Sistem verimliliğini ve iş hacmini değerlendirmek için iş işleme modellerini ve analitik teknikleri uygulamak.
-- Bilgisayar sistemlerinin performans analizi için simülasyon tekniklerinde yeterlilik geliştirmek.
-- Optimum performans için sistem donanım ve yazılım kaynaklarını yönetmek ve kontrol etmek.
-- Çeşitli operasyonel ortamlarda çoklu işlem sistemlerinin performansını analiz etme ve değerlendirme.
-- Karmaşık bilgisayar sistemlerinin performansını modellemek ve tahmin etmek için uygun araç ve teknikleri kullanmak.
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe470.tr.md
+++ b/content/courses/cmpe470.tr.md
@@ -23,7 +23,7 @@ aliases:
 | Ders Kredisi | 3 |
 | AKTS | 6 |
 | Notlandırma Sistemi | Harf Notu |
-| Önkoşul dersleri | CMPE'de Kıdemli Statüsü |
+| Önkoşul dersleri | Yok |
 | Eşkoşul dersleri | Yok |
 
 {{< /table >}}

--- a/content/courses/cmpe470.tr.md
+++ b/content/courses/cmpe470.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe470
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe470.tr.md
+++ b/content/courses/cmpe470.tr.md
@@ -1,0 +1,51 @@
+---
+title: CMPE470
+description: Bilgisayar Performansı Değerlendirmesi
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe470/1400
+aliases:
+  - undergraduate/courses/cmpe470
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE470 |
+| Ders Başlığı | Bilgisayar Performansı Değerlendirmesi |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | -- |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE'de Kıdemli Statüsü |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Bilgisayar performans değerlendirmesinin doğası. İş işleme modelleri. Analitik teknikler. Simülasyon. Sistem donanım ve yazılım kaynaklarının yönetimi ve kontrolü. Çok işlemli sistemlerin performansı.
+
+## Dersin Öğrenme Çıktıları
+
+- Bilgisayar sistem performansını değerlendirmeye yönelik temel ilke ve metodolojileri anlamak.
+- Sistem verimliliğini ve iş hacmini değerlendirmek için iş işleme modellerini ve analitik teknikleri uygulamak.
+- Bilgisayar sistemlerinin performans analizi için simülasyon tekniklerinde yeterlilik geliştirmek.
+- Optimum performans için sistem donanım ve yazılım kaynaklarını yönetmek ve kontrol etmek.
+- Çeşitli operasyonel ortamlarda çoklu işlem sistemlerinin performansını analiz etme ve değerlendirme.
+- Karmaşık bilgisayar sistemlerinin performansını modellemek ve tahmin etmek için uygun araç ve teknikleri kullanmak.
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe470" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe470" cols="3">}}

--- a/content/courses/cmpe470.tr.md
+++ b/content/courses/cmpe470.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe470
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe475.en.md
+++ b/content/courses/cmpe475.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe475/1400
 aliases:
   - undergraduate/courses/cmpe475
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe475.en.md
+++ b/content/courses/cmpe475.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe475/1400
 aliases:
   - undergraduate/courses/cmpe475
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe475.en.md
+++ b/content/courses/cmpe475.en.md
@@ -7,9 +7,42 @@ aliases:
   - undergraduate/courses/cmpe475
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE475 |
+| Course Title | Computer Networks |
+| Language of Instruction | English |
+| Course Semester | Fall |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | None |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
 
-## Course Learning Outcome
+Overview of computer networks: Network architecture and the ISO model. Network topology: Connectivity analysis, delay analysis and backbone analysis. Physical layer: Transmission and multiplexing, terminal handling, errors. Data link layer and link protocols. Network layer: Routing and congestion, satellite and packet radio networks, local networks. Transmission and session layer. Presentation layer. Application layer.
+
+
+## Course Learning Outcomes
+
+- Understand the basic concepts and methodologies for evaluating the performance of computer systems
+- Develop skills in job processing models and analytical techniques for system performance analysis
+- Utilize simulation techniques to assess and predict the performance of computing systems
+- Manage and optimize system hardware and software resources for better performance
+- Analyze the performance of multiprocessor systems and their efficiency in various configurations
+- Apply performance evaluation methods to solve real-world problems in computing environments
+
 
 ## Current Instructor
 

--- a/content/courses/cmpe475.en.md
+++ b/content/courses/cmpe475.en.md
@@ -34,16 +34,6 @@ aliases:
 Overview of computer networks: Network architecture and the ISO model. Network topology: Connectivity analysis, delay analysis and backbone analysis. Physical layer: Transmission and multiplexing, terminal handling, errors. Data link layer and link protocols. Network layer: Routing and congestion, satellite and packet radio networks, local networks. Transmission and session layer. Presentation layer. Application layer.
 
 
-## Course Learning Outcomes
-
-- Understand the basic concepts and methodologies for evaluating the performance of computer systems
-- Develop skills in job processing models and analytical techniques for system performance analysis
-- Utilize simulation techniques to assess and predict the performance of computing systems
-- Manage and optimize system hardware and software resources for better performance
-- Analyze the performance of multiprocessor systems and their efficiency in various configurations
-- Apply performance evaluation methods to solve real-world problems in computing environments
-
-
 ## Current Instructor
 
 {{< people tag="cmpe475" cols="2">}}

--- a/content/courses/cmpe475.tr.md
+++ b/content/courses/cmpe475.tr.md
@@ -33,15 +33,6 @@ aliases:
 
 Bilgisayar ağlarına genel bakış: Ağ mimarisi ve ISO modeli. Ağ topolojisi: Bağlantı analizi, gecikme analizi ve omurga analizi. Fiziksel katman: İletim ve çoğullama, terminal işleme, hatalar. Veri bağlantı katmanı ve bağlantı protokolleri. Ağ katmanı: Yönlendirme ve tıkanıklık, uydu ve paket radyo ağları, yerel ağlar. İletim ve oturum katmanı. Sunum katman. Uygulama katmanı.
 
-## Dersin Öğrenme Çıktıları
-
-- Bilgisayar sistemlerinin performansını değerlendirmeye yönelik temel kavram ve metodolojileri anlamak.
-- Sistem performans analizi için iş işleme modelleri ve analitik teknikler konusunda beceriler geliştirmek.
-- Bilgi işlem sistemlerinin performansını değerlendirmek ve tahmin etmek için simülasyon tekniklerini kullanmak.
-- Daha iyi performans için sistem donanım ve yazılım kaynaklarını yönetme ve optimize etme.
-- Çok işlemcili sistemlerin performansını ve çeşitli konfigürasyonlardaki verimliliklerini analiz etmek.
-- Bilgisayar ortamlarındaki gerçek dünya problemlerini çözmek için performans değerlendirme yöntemlerini uygulayabilme.
-
 ## Dersi Veren Öğretim Üyesi
 
 {{< people tag="cmpe475" cols="2">}}

--- a/content/courses/cmpe475.tr.md
+++ b/content/courses/cmpe475.tr.md
@@ -1,0 +1,51 @@
+---
+title: CMPE475
+description: Bilgisayar Ağları
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe475/1400
+aliases:
+  - undergraduate/courses/cmpe475
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE475 |
+| Ders Başlığı | Bilgisayar Ağları |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Güz |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | Yok |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Bilgisayar ağlarına genel bakış: Ağ mimarisi ve ISO modeli. Ağ topolojisi: Bağlantı analizi, gecikme analizi ve omurga analizi. Fiziksel katman: İletim ve çoğullama, terminal işleme, hatalar. Veri bağlantı katmanı ve bağlantı protokolleri. Ağ katmanı: Yönlendirme ve tıkanıklık, uydu ve paket radyo ağları, yerel ağlar. İletim ve oturum katmanı. Sunum katman. Uygulama katmanı.
+
+## Dersin Öğrenme Çıktıları
+
+- Bilgisayar sistemlerinin performansını değerlendirmeye yönelik temel kavram ve metodolojileri anlamak.
+- Sistem performans analizi için iş işleme modelleri ve analitik teknikler konusunda beceriler geliştirmek.
+- Bilgi işlem sistemlerinin performansını değerlendirmek ve tahmin etmek için simülasyon tekniklerini kullanmak.
+- Daha iyi performans için sistem donanım ve yazılım kaynaklarını yönetme ve optimize etme.
+- Çok işlemcili sistemlerin performansını ve çeşitli konfigürasyonlardaki verimliliklerini analiz etmek.
+- Bilgisayar ortamlarındaki gerçek dünya problemlerini çözmek için performans değerlendirme yöntemlerini uygulayabilme.
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe475" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe475" cols="3">}}

--- a/content/courses/cmpe475.tr.md
+++ b/content/courses/cmpe475.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe475
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe475.tr.md
+++ b/content/courses/cmpe475.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe475
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe476.en.md
+++ b/content/courses/cmpe476.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe476/1400
 aliases:
   - undergraduate/courses/cmpe476
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe476.en.md
+++ b/content/courses/cmpe476.en.md
@@ -7,9 +7,41 @@ aliases:
   - undergraduate/courses/cmpe476
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE476 |
+| Course Title | Distributed Systems |
+| Language of Instruction | English |
+| Course Semester | Spring |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | None |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
 ## Catalog Description
 
-## Course Learning Outcome
+Transport layer services and protocols. Internet protocols TCP and UDP. ATM Adaptation Layer protocols. Client-server and peer-to-peer programming models. Network programming. Remote procedure call. Application layer issues and protocols. Network security. Domain name system. Network management. Electronic mail and news services. Overview of distributed systems and structures. Distributed file and directory systems. Distributed coordination, concurrency control, deadlock detection and election algorithms.
+
+## Course Learning Outcomes
+
+- Understand transport layer services and protocols, including TCP, UDP, and ATM Adaptation Layer protocols
+- Develop programming skills for client-server and peer-to-peer models using network programming techniques
+- Implement and analyze remote procedure calls and the associated application layer issues and protocols
+- Gain knowledge of network security concepts and protocols, including mechanisms for ensuring secure communication
+- Comprehend the operation and structure of the Domain Name System (DNS) and network management protocols
+- Apply electronic mail and news service protocols in practical scenarios
+- Understand the core principles of distributed systems, including file and directory systems, and their management
+- Analyze and implement distributed coordination techniques, such as concurrency control, deadlock detection, and election algorithms
 
 ## Current Instructor
 

--- a/content/courses/cmpe476.en.md
+++ b/content/courses/cmpe476.en.md
@@ -32,16 +32,6 @@ aliases:
 
 Transport layer services and protocols. Internet protocols TCP and UDP. ATM Adaptation Layer protocols. Client-server and peer-to-peer programming models. Network programming. Remote procedure call. Application layer issues and protocols. Network security. Domain name system. Network management. Electronic mail and news services. Overview of distributed systems and structures. Distributed file and directory systems. Distributed coordination, concurrency control, deadlock detection and election algorithms.
 
-## Course Learning Outcomes
-
-- Understand transport layer services and protocols, including TCP, UDP, and ATM Adaptation Layer protocols
-- Develop programming skills for client-server and peer-to-peer models using network programming techniques
-- Implement and analyze remote procedure calls and the associated application layer issues and protocols
-- Gain knowledge of network security concepts and protocols, including mechanisms for ensuring secure communication
-- Comprehend the operation and structure of the Domain Name System (DNS) and network management protocols
-- Apply electronic mail and news service protocols in practical scenarios
-- Understand the core principles of distributed systems, including file and directory systems, and their management
-- Analyze and implement distributed coordination techniques, such as concurrency control, deadlock detection, and election algorithms
 
 ## Current Instructor
 

--- a/content/courses/cmpe476.en.md
+++ b/content/courses/cmpe476.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe476/1400
 aliases:
   - undergraduate/courses/cmpe476
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe476.tr.md
+++ b/content/courses/cmpe476.tr.md
@@ -1,0 +1,54 @@
+---
+title: CMPE476
+description: Dağıtık Sistemler
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe476/1400
+aliases:
+  - undergraduate/courses/cmpe476
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE476 |
+| Ders Başlığı | Dağıtık Sistemler |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Bahar |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | Yok |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Taşıma katmanı hizmetleri ve protokolleri. İnternet protokolleri TCP ve UDP. ATM Adaptasyon Katmanı protokolleri. İstemci-sunucu ve eşler arası programlama modelleri. Ağ programlama. Uzaktan yordam çağrısı. Uygulama katmanı sorunları ve protokolleri. Ağ güvenliği. Alan adı sistemi. Ağ yönetimi. Elektronik posta ve haber servisleri. Dağıtık sistemlere ve yapılara genel bakış. Dağıtık dosya ve dizin sistemleri. Dağıtık koordinasyon, eşzamanlılık kontrolü, kilitlenme tespiti ve seçim algoritmaları.
+
+## Dersin Öğrenme Çıktıları
+
+- TCP, UDP ve ATM Adaptasyon Katmanı protokolleri dahil olmak üzere aktarım katmanı hizmetlerini ve protokollerini anlama
+- Ağ programlama tekniklerini kullanarak istemci-sunucu ve eşler arası modeller için programlama becerileri geliştirmek
+- Uzaktan yordam çağrılarını ve ilgili uygulama katmanı sorunlarını ve protokollerini uygulamak ve analiz etmek
+- Güvenli iletişimi sağlamaya yönelik mekanizmalar da dahil olmak üzere ağ güvenliği kavramları ve protokolleri hakkında bilgi edinme
+- Alan Adı Sisteminin (DNS) ve ağ yönetim protokollerinin işleyişini ve yapısını kavrayabilme
+- Pratik senaryolarda elektronik posta ve haber servisi protokollerini uygulamak
+- Dosya ve dizin sistemleri ve bunların yönetimi de dahil olmak üzere dağıtık sistemlerin temel ilkelerini anlamak
+- Eşzamanlılık kontrolü, kilitlenme tespiti ve seçim algoritmaları gibi dağıtık koordinasyon tekniklerini analiz etme ve uygulama
+
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe476" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe476" cols="3">}}

--- a/content/courses/cmpe476.tr.md
+++ b/content/courses/cmpe476.tr.md
@@ -33,17 +33,6 @@ aliases:
 
 Taşıma katmanı hizmetleri ve protokolleri. İnternet protokolleri TCP ve UDP. ATM Adaptasyon Katmanı protokolleri. İstemci-sunucu ve eşler arası programlama modelleri. Ağ programlama. Uzaktan yordam çağrısı. Uygulama katmanı sorunları ve protokolleri. Ağ güvenliği. Alan adı sistemi. Ağ yönetimi. Elektronik posta ve haber servisleri. Dağıtık sistemlere ve yapılara genel bakış. Dağıtık dosya ve dizin sistemleri. Dağıtık koordinasyon, eşzamanlılık kontrolü, kilitlenme tespiti ve seçim algoritmaları.
 
-## Dersin Öğrenme Çıktıları
-
-- TCP, UDP ve ATM Adaptasyon Katmanı protokolleri dahil olmak üzere aktarım katmanı hizmetlerini ve protokollerini anlama
-- Ağ programlama tekniklerini kullanarak istemci-sunucu ve eşler arası modeller için programlama becerileri geliştirmek
-- Uzaktan yordam çağrılarını ve ilgili uygulama katmanı sorunlarını ve protokollerini uygulamak ve analiz etmek
-- Güvenli iletişimi sağlamaya yönelik mekanizmalar da dahil olmak üzere ağ güvenliği kavramları ve protokolleri hakkında bilgi edinme
-- Alan Adı Sisteminin (DNS) ve ağ yönetim protokollerinin işleyişini ve yapısını kavrayabilme
-- Pratik senaryolarda elektronik posta ve haber servisi protokollerini uygulamak
-- Dosya ve dizin sistemleri ve bunların yönetimi de dahil olmak üzere dağıtık sistemlerin temel ilkelerini anlamak
-- Eşzamanlılık kontrolü, kilitlenme tespiti ve seçim algoritmaları gibi dağıtık koordinasyon tekniklerini analiz etme ve uygulama
-
 
 ## Dersi Veren Öğretim Üyesi
 

--- a/content/courses/cmpe476.tr.md
+++ b/content/courses/cmpe476.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe476
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe476.tr.md
+++ b/content/courses/cmpe476.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe476
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe478.en.md
+++ b/content/courses/cmpe478.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe478/1400
 aliases:
   - undergraduate/courses/cmpe478
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe478.en.md
+++ b/content/courses/cmpe478.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe478/1400
 aliases:
   - undergraduate/courses/cmpe478
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe478.en.md
+++ b/content/courses/cmpe478.en.md
@@ -7,9 +7,37 @@ aliases:
   - undergraduate/courses/cmpe478
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE478 |
+| Course Title | Parallel Processing |
+| Language of Instruction | English |
+| Course Semester | Fall |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | CMPE322 |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
 ## Catalog Description
 
+Parallel machine and performance models: PRAM, speedup, work efficiency, scalability, Brent's theorem. Parallel programming with message passing and multi-threading libraries. Parallel algorithms: Prefix computation, pointer jumping, list ranking, Euler tours on trees, sorting. Parallel architectures: Multiprocessors, multicomputers and Flynn's taxonomy, SIMD, MIMD, SPMD, interconnection topologies. Load balancing and graph partitioning methods.
+
 ## Course Learning Outcome
+
+- Explain high-performance computing terminology and concepts
+- Design scalable parallel algorithms
+- Develop parallel programs for distributed memory systems using MPI and for shared memory systems using OpenMP/Pthreads
+- Develop parallel programs for GPUs
 
 ## Current Instructor
 

--- a/content/courses/cmpe478.tr.md
+++ b/content/courses/cmpe478.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe478
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe478.tr.md
+++ b/content/courses/cmpe478.tr.md
@@ -1,0 +1,50 @@
+---
+title: CMPE478
+description: Paralel İşlem Görme
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe478/1400
+aliases:
+  - undergraduate/courses/cmpe478
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE478 |
+| Ders Başlığı | Paralel İşlem Görme |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Güz |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE322 |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Paralel makine ve performans modelleri: PRAM, hızlanma, iş verimliliği, ölçeklenebilirlik, Brent teoremi. Mesaj geçişi ve çoklu iş parçacığı kütüphaneleri ile paralel programlama. Paralel algoritmalar: Önek hesaplama, işaretçi atlama, liste sıralama, ağaçlar üzerinde Euler turları, sıralama. Paralel mimariler: Çoklu işlemciler, çoklu bilgisayarlar ve Flynn'in taksonomisi, SIMD, MIMD, SPMD, ara bağlantı topolojileri. Yük dengeleme ve çizge bölümleme yöntemleri.
+
+## Dersin Öğrenme Çıktıları
+
+- Yüksek performanslı hesaplama terminolojisini ve kavramlarını açıklayabilme
+- Ölçeklenebilir paralel algoritmalar tasarlama
+- MPI kullanarak dağıtık bellek sistemleri için ve OpenMP/Pthreads kullanarak paylaşımlı bellek sistemleri için paralel programlar geliştirebilme
+- GPU'lar için paralel programlar geliştirme
+
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe478" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe478" cols="3">}}

--- a/content/courses/cmpe478.tr.md
+++ b/content/courses/cmpe478.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe478
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe480.en.md
+++ b/content/courses/cmpe480.en.md
@@ -6,7 +6,9 @@ thumbnail: https://picsum.photos/seed/cmpe480/1400
 aliases:
   - undergraduate/courses/cmpe480
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe480.en.md
+++ b/content/courses/cmpe480.en.md
@@ -6,7 +6,7 @@ thumbnail: https://picsum.photos/seed/cmpe480/1400
 aliases:
   - undergraduate/courses/cmpe480
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe480.en.md
+++ b/content/courses/cmpe480.en.md
@@ -7,9 +7,40 @@ aliases:
   - undergraduate/courses/cmpe480
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE480 |
+| Course Title | Introduction to Artificial Intelligence|
+| Language of Instruction | English |
+| Course Semester | Fall |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 3 |
+| ECTS | 6 |
+| Grading Mode | Letter Grade |
+| Prerequisites | Consent |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
 
-## Course Learning Outcome
+Representation of knowledge. Search and heuristic programming. Logic and logic programming. Application areas of artificial intelligence: problem solving, games and puzzles, expert systems, planning, learning, vision, and natural language understanding. Exercises in an artificial intelligence language.
+
+## Course Learning Outcomes
+
+- Understand the representation of knowledge in artificial intelligence systems
+- Apply search algorithms and heuristic programming techniques to solve AI problems
+- Develop proficiency in logic and logic programming, utilizing them for AI applications
+- Explore various application areas of AI, such as problem-solving, games, expert systems, planning, learning, vision, and natural language understanding
+- Implement AI techniques using an artificial intelligence programming language
+- Analyze and solve real-world problems using AI methodologies, including search strategies and knowledge-based systems
 
 ## Current Instructor
 

--- a/content/courses/cmpe480.en.md
+++ b/content/courses/cmpe480.en.md
@@ -33,15 +33,6 @@ aliases:
 
 Representation of knowledge. Search and heuristic programming. Logic and logic programming. Application areas of artificial intelligence: problem solving, games and puzzles, expert systems, planning, learning, vision, and natural language understanding. Exercises in an artificial intelligence language.
 
-## Course Learning Outcomes
-
-- Understand the representation of knowledge in artificial intelligence systems
-- Apply search algorithms and heuristic programming techniques to solve AI problems
-- Develop proficiency in logic and logic programming, utilizing them for AI applications
-- Explore various application areas of AI, such as problem-solving, games, expert systems, planning, learning, vision, and natural language understanding
-- Implement AI techniques using an artificial intelligence programming language
-- Analyze and solve real-world problems using AI methodologies, including search strategies and knowledge-based systems
-
 ## Current Instructor
 
 {{< people tag="cmpe480" cols="2">}}

--- a/content/courses/cmpe480.en.md
+++ b/content/courses/cmpe480.en.md
@@ -22,7 +22,7 @@ aliases:
 | Course Credits | 3 |
 | ECTS | 6 |
 | Grading Mode | Letter Grade |
-| Prerequisites | Consent |
+| Prerequisites | None |
 | Corequisites | None |
 
 {{< /table >}}

--- a/content/courses/cmpe480.tr.md
+++ b/content/courses/cmpe480.tr.md
@@ -23,7 +23,7 @@ aliases:
 | Ders Kredisi | 3 |
 | AKTS | 6 |
 | Notlandırma Sistemi | Harf Notu |
-| Önkoşul dersleri | Egitmen Kabulu |
+| Önkoşul dersleri | Yok |
 | Eşkoşul dersleri | Yok |
 
 {{< /table >}}

--- a/content/courses/cmpe480.tr.md
+++ b/content/courses/cmpe480.tr.md
@@ -1,0 +1,51 @@
+---
+title: CMPE480
+description: Yapay Zekaya Giriş
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe480/1400
+aliases:
+  - undergraduate/courses/cmpe480
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE480 |
+| Ders Başlığı | Yapay Zekaya Giriş |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Güz |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 3 |
+| AKTS | 6 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | Egitmen Kabulu |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+Bilginin temsili. Arama ve sezgisel programlama. Mantık ve mantık programlama. Yapay zekanın uygulama alanları: problem çözme, oyunlar ve bulmacalar, uzman sistemler, planlama, öğrenme, görme ve doğal dil anlama. Yapay zeka dilinde alıştırmalar.
+
+## Dersin Öğrenme Çıktıları
+
+- Yapay zeka sistemlerinde bilginin temsilini anlamak
+- AI problemlerini çözmek için arama algoritmalarını ve sezgisel programlama tekniklerini uygulayabilme
+- Mantık ve mantık programlama konusunda yeterlilik geliştirmek, bunları yapay zeka uygulamaları için kullanmak
+- Problem çözme, oyunlar, uzman sistemler, planlama, öğrenme, görme ve doğal dil anlama gibi çeşitli yapay zeka uygulama alanlarını keşfetmek
+- Bir yapay zeka programlama dili kullanarak yapay zeka tekniklerini uygulamak
+- Arama stratejileri ve bilgi tabanlı sistemler de dahil olmak üzere yapay zeka metodolojilerini kullanarak gerçek dünya problemlerini analiz etme ve çözme
+
+## Dersi Veren Öğretim Üyesi
+
+{{< people tag="cmpe480" cols="2">}}
+
+## Dersi Veren Önceki Öğretim Üyeleri
+
+{{< people_alt tag="former-cmpe480" cols="3">}}

--- a/content/courses/cmpe480.tr.md
+++ b/content/courses/cmpe480.tr.md
@@ -33,15 +33,6 @@ aliases:
 
 Bilginin temsili. Arama ve sezgisel programlama. Mantık ve mantık programlama. Yapay zekanın uygulama alanları: problem çözme, oyunlar ve bulmacalar, uzman sistemler, planlama, öğrenme, görme ve doğal dil anlama. Yapay zeka dilinde alıştırmalar.
 
-## Dersin Öğrenme Çıktıları
-
-- Yapay zeka sistemlerinde bilginin temsilini anlamak
-- AI problemlerini çözmek için arama algoritmalarını ve sezgisel programlama tekniklerini uygulayabilme
-- Mantık ve mantık programlama konusunda yeterlilik geliştirmek, bunları yapay zeka uygulamaları için kullanmak
-- Problem çözme, oyunlar, uzman sistemler, planlama, öğrenme, görme ve doğal dil anlama gibi çeşitli yapay zeka uygulama alanlarını keşfetmek
-- Bir yapay zeka programlama dili kullanarak yapay zeka tekniklerini uygulamak
-- Arama stratejileri ve bilgi tabanlı sistemler de dahil olmak üzere yapay zeka metodolojilerini kullanarak gerçek dünya problemlerini analiz etme ve çözme
-
 ## Dersi Veren Öğretim Üyesi
 
 {{< people tag="cmpe480" cols="2">}}

--- a/content/courses/cmpe480.tr.md
+++ b/content/courses/cmpe480.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe480
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe480.tr.md
+++ b/content/courses/cmpe480.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe480
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe492.en.md
+++ b/content/courses/cmpe492.en.md
@@ -9,4 +9,40 @@ aliases:
   - undergraduate/courses/cmpe492
 ---
 
+## Course Information
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+| :-- | :-- |
+| Faculty | Faculty of Engineering |
+| Course Code | CMPE491-492 |
+| Course Title | Project In Computer Engineering |
+| Language of Instruction | English |
+| Course Semester | Spring |
+| Course Hours | Lecture: 3, PS:0, Labs: 0 |
+| Course Credits | 4 |
+| ECTS | 7 |
+| Grading Mode | Letter Grade |
+| Prerequisites | Senior in CMPE |
+| Corequisites | None |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+
 ## Catalog Description
+
+Instructions for 491/492 Project Selection and Registration
+
+1.    Read project descriptions posted by CmpE project advisors, discuss projects you are interested in with project advisors and decide on a project.
+
+2.    Note that your GPA must be over 2.00 to register for a 491 project.    
+
+3.    Fill the [project registration form](https://www.cmpe.boun.edu.tr/sites/default/files/cmpe-491-492-registrationform.doc) and get the approval of your project advisor.    
+
+4.    Return the registration form, approved by your project advisor, to the CmpE 491/492 coordinator before the registration period ends.
+
+5.    Enroll to CmpE 491/492 through the Registration system.    
+
+6.    Repeat the above steps, if you want to make a change in your project selection

--- a/content/courses/cmpe492.en.md
+++ b/content/courses/cmpe492.en.md
@@ -8,7 +8,9 @@ aliases:
   - /undergraduate/courses/cmpe491
   - undergraduate/courses/cmpe492
 ---
-{{< warning >}}
+
+{{< under-construction-warning >}}
+
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe492.en.md
+++ b/content/courses/cmpe492.en.md
@@ -8,7 +8,7 @@ aliases:
   - /undergraduate/courses/cmpe491
   - undergraduate/courses/cmpe492
 ---
-
+{{< warning >}}
 ## Course Information
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe492.tr.md
+++ b/content/courses/cmpe492.tr.md
@@ -1,0 +1,47 @@
+---
+title: CMPE491-492
+description: Proje
+metadata: none
+thumbnail: https://picsum.photos/seed/cmpe492/1400
+aliases:
+  - undergraduate/courses/cmpe492
+---
+
+
+## Ders Bilgileri
+
+<!-- prettier-ignore-start -->
+{{< table class="table-hover table-sm" >}}
+|||
+|:--|:--|
+| Fakülte | Mühendislik Fakültesi |
+| Ders Kodu | CMPE491-492 |
+| Ders Başlığı | Proje |
+| Öğretim Dili | İngilizce |
+| Ders Dönemi | Bahar |
+| Ders Saatleri | Ders: 3, PS:0, Laboratuvar:0 |
+| Ders Kredisi | 4 |
+| AKTS | 7 |
+| Notlandırma Sistemi | Harf Notu |
+| Önkoşul dersleri | CMPE'de Kıdemli Statüsü  |
+| Eşkoşul dersleri | Yok |
+
+{{< /table >}}
+<!-- prettier-ignore-end -->
+
+## Katalog Tanımı
+
+
+491/492 Proje Seçimi ve Kaydı için Talimatlar
+
+1.    CmpE proje danışmanları tarafından yayınlanan proje açıklamalarını okuyun, ilgilendiğiniz projeleri proje danışmanlarıyla tartışın ve bir projeye karar verin.
+
+2.    Bir 491 projesine kaydolmak için genel not ortalamanızın 2.00'ın üzerinde olması gerektiğini unutmayın.    
+
+3.    [Projeye Kayıt formunu](https://www.cmpe.boun.edu.tr/sites/default/files/cmpe-491-492-registrationform.doc) doldurun ve proje danışmanınızın onayını alın.    
+
+4.    Proje danışmanınız tarafından onaylanan kayıt formunu, kayıt dönemi sona ermeden önce CmpE 491/492 koordinatörüne iade edin.
+
+5.    Kayıt sistemi üzerinden CmpE 491/492'ye kaydolun.    
+
+6.    Proje seçiminizde bir değişiklik yapmak isterseniz yukarıdaki adımları tekrarlayın

--- a/content/courses/cmpe492.tr.md
+++ b/content/courses/cmpe492.tr.md
@@ -7,7 +7,8 @@ aliases:
   - undergraduate/courses/cmpe492
 ---
 
-{{< warning_tr >}}
+{{< under-construction-warning >}}
+
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/content/courses/cmpe492.tr.md
+++ b/content/courses/cmpe492.tr.md
@@ -7,7 +7,7 @@ aliases:
   - undergraduate/courses/cmpe492
 ---
 
-
+{{< warning_tr >}}
 ## Ders Bilgileri
 
 <!-- prettier-ignore-start -->

--- a/data/bouncmpe/people/akarun-lale.json
+++ b/data/bouncmpe/people/akarun-lale.json
@@ -2,6 +2,6 @@
   "email": "akarun@bogazici.edu.tr",
   "name": "Lale Akarun",
   "position": "full-professor",
-  "tags": ["faculty", "former-cmpe322", "former-cmpe344", "advisor-2"],
+  "tags": ["faculty", "cmpe460","former-cmpe322", "former-cmpe344", "advisor-2"],
   "type": "person"
 }

--- a/data/bouncmpe/people/akin-levent.json
+++ b/data/bouncmpe/people/akin-levent.json
@@ -2,6 +2,6 @@
   "email": "akin@bogazici.edu.tr",
   "name": "Levent Akın",
   "position": "full-professor",
-  "tags": ["former-faculty", "former-cmpe434"],
+  "tags": ["former-faculty", "former-cmpe434", "former-cmpe480"],
   "type": "person"
 }

--- a/data/bouncmpe/people/alpaydin-ethem.json
+++ b/data/bouncmpe/people/alpaydin-ethem.json
@@ -1,6 +1,6 @@
 {
   "name": "Ethem Alpaydın",
   "position": "full-professor",
-  "tags": ["former-faculty", "former-cmpe343"],
+  "tags": ["former-faculty", "former-cmpe343", "former-cmpe462"],
   "type": "person"
 }

--- a/data/bouncmpe/people/caglayan-ufuk.json
+++ b/data/bouncmpe/people/caglayan-ufuk.json
@@ -1,6 +1,6 @@
 {
   "name": "Mehmet Ufuk Çağlayan",
   "position": "full-professor",
-  "tags": ["former-faculty"],
+  "tags": ["former-faculty", "former-cmpe475", "former-cmpe476"],
   "type": "person"
 }

--- a/data/bouncmpe/people/cemgil-taylan.json
+++ b/data/bouncmpe/people/cemgil-taylan.json
@@ -6,7 +6,8 @@
     "former-faculty",
     "former-postdoc",
     "former-teaching-assistant",
-    "adjunct-faculty"
+    "adjunct-faculty",
+    "former-cmpe462"
   ],
   "type": "person"
 }

--- a/data/bouncmpe/people/gungor-tunga.json
+++ b/data/bouncmpe/people/gungor-tunga.json
@@ -2,6 +2,6 @@
   "email": "gungort@bogazici.edu.tr",
   "name": "Tunga Güngör",
   "position": "full-professor",
-  "tags": ["faculty", "cmpe300", "advisor-x"],
+  "tags": ["faculty", "cmpe300", "advisor-x", "former-cmpe480"],
   "type": "person"
 }

--- a/data/bouncmpe/people/gurgen-fikret.json
+++ b/data/bouncmpe/people/gurgen-fikret.json
@@ -2,6 +2,6 @@
   "email": "gurgen@bogazici.edu.tr",
   "name": "Fikret Gürgen",
   "position": "full-professor",
-  "tags": ["faculty", "cmpe210"],
+  "tags": ["faculty", "cmpe210", "former-cmpe451"],
   "type": "person"
 }

--- a/data/bouncmpe/people/ozturan-can.json
+++ b/data/bouncmpe/people/ozturan-can.json
@@ -2,6 +2,6 @@
   "email": "ozturaca@bogazici.edu.tr",
   "name": "Can Özturan",
   "position": "full-professor",
-  "tags": ["faculty", "double-major", "cmpe230", "cmpe425"],
+  "tags": ["faculty", "double-major", "cmpe230", "cmpe425", "cmpe478"],
   "type": "person"
 }

--- a/data/bouncmpe/people/tosun-oguz.json
+++ b/data/bouncmpe/people/tosun-oguz.json
@@ -2,6 +2,6 @@
   "email": "tosuno@bogazici.edu.tr",
   "name": "Oğuz Tosun",
   "position": "full-professor",
-  "tags": ["emeritus", "former-cmpe344"],
+  "tags": ["emeritus", "former-cmpe344", "former-cmpe446"],
   "type": "person"
 }

--- a/data/bouncmpe/people/ugur-emre.json
+++ b/data/bouncmpe/people/ugur-emre.json
@@ -2,6 +2,6 @@
   "email": "emre.ugur@bogazici.edu.tr",
   "name": "Emre Uğur",
   "position": "assistant-professor",
-  "tags": ["faculty", "cmpe150", "former-cmpe343"],
+  "tags": ["faculty", "cmpe150", "cmpe480", "former-cmpe343", "former-cmpe462"],
   "type": "person"
 }

--- a/data/bouncmpe/people/yilmaz-birkan.json
+++ b/data/bouncmpe/people/yilmaz-birkan.json
@@ -10,7 +10,8 @@
     "elective",
     "former-cmpe250",
     "cmpe220",
-    "advisor-4"
+    "advisor-4",
+    "former-cmpe476"
   ],
   "type": "person"
 }

--- a/data/bouncmpe/people/yurdakul-arda.json
+++ b/data/bouncmpe/people/yurdakul-arda.json
@@ -2,6 +2,6 @@
   "email": "yurdakul@bogazici.edu.tr",
   "name": "Arda Yurdakul",
   "position": "full-professor",
-  "tags": ["faculty", "graduate-studies", "curriculum", "cmpe443"],
+  "tags": ["faculty", "graduate-studies", "curriculum", "cmpe443", "cmpe446"],
   "type": "person"
 }

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -141,3 +141,6 @@ technical-staff:
 
 building-head:
   other: head of building
+
+under-construction-warning:
+  other: The information on this page is under construction.

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -118,6 +118,8 @@ technical-staff:
 building-head:
   other: bina amiri
 
+under-construction-warning:
+  other: Bu sayfa yapım aşamasındadır. Sayfadaki bilgilerde hatalar olabilir.
 
 course-description:
   other: ders tanımı
@@ -169,3 +171,4 @@ languageSwitcherLabel:
   other: Dil Seçimi
 toc:
   other: İçindekiler
+

--- a/layouts/shortcodes/under-construction-warning.html
+++ b/layouts/shortcodes/under-construction-warning.html
@@ -1,4 +1,4 @@
 <div class="alert alert-warning alert-dismissible fade show text-center" role="alert">
-    <small>The information on this page is under construction.</small>
+    <small>{{ i18n "under-construction-warning" }}</small>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 </div>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,0 +1,4 @@
+<div class="alert alert-warning alert-dismissible fade show text-center" role="alert">
+    <small>The information on this page is under construction.</small>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,4 +1,0 @@
-<div class="alert alert-warning alert-dismissible fade show text-center" role="alert">
-    <small>The information on this page is under construction.</small>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-</div>

--- a/layouts/shortcodes/warning_tr.html
+++ b/layouts/shortcodes/warning_tr.html
@@ -1,0 +1,4 @@
+<div class="alert alert-warning alert-dismissible fade show text-center" role="alert">
+    <small>Bu sayfa yapım aşamasındadır. Sayfadaki bilgiler gerçeği yansıtmayabilir.</small>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/layouts/shortcodes/warning_tr.html
+++ b/layouts/shortcodes/warning_tr.html
@@ -1,4 +1,0 @@
-<div class="alert alert-warning alert-dismissible fade show text-center" role="alert">
-    <small>Bu sayfa yapım aşamasındadır. Sayfadaki bilgiler gerçeği yansıtmayabilir.</small>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-</div>


### PR DESCRIPTION
Questions to solve:
- can prerequisites only refer to courses or can they include the consent of the lecturer, the requirement to be a senior or the requirements written in the course description (such as cmpe434)?
- cmpe462 has never been given in the fall period except this year. Still, would it be appropriate to write fall in the content
- It does not appear anywhere except the faculty page for cmpe470, I could not see the course in the past years. Where can I find information about the course?
- will the course outcome be written for cmpe492
- Shall we start uploading class and instructor photos in our updates?