### PR TITLE
related-labs for research pages

### DIFF
--- a/content/prospective/_index.tr.md
+++ b/content/prospective/_index.tr.md
@@ -1,7 +1,6 @@
 ---
 title: Yeni öğrencilerimizi bekliyoruz!
 description: Boğaziçi Üniversitesi Bilgisayar Mühendisliği Bölümü'ne katılmak, Türkiye'nin en prestijli ve saygın akademik ailelerinden birinin parçası olmaktır. Bu bölüm, size sağlam bir teorik temel ve sektörde aranan pratik beceriler kazandırarak, bilgisayar mühendisliği alanında başarılı bir kariyere hazırlar.
-<!-- Some revisions from irem -->
 metadata: none
 card_links:
   - title: "#neden-bilgisayar"

--- a/content/research/artificial-intelligence.en.md
+++ b/content/research/artificial-intelligence.en.md
@@ -4,6 +4,11 @@ description: " "
 metadata: none
 thumbnail: 
     url: https://picsum.photos/seed/artificialintelligence/1400
+related_labs:
+  - name: Cognitive Learning and Robotics (COLORS) LAB
+    url: https://colors.cmpe.boun.edu.tr
+  - name: Artificial Intelligence Lab
+    url: http://ailab.cmpe.boun.edu.tr
 ---
 
 {{< under-construction-warning >}}

--- a/layouts/partials/related-labs.html
+++ b/layouts/partials/related-labs.html
@@ -1,0 +1,10 @@
+{{ with .Params.related_labs }}
+<div class="related-box" style="background:#f5f8fc; padding:1rem; border-radius:8px; margin-top:2rem;">
+  <h3>Related labs in the Computer Engineering Department:</h3>
+  <ul>
+    {{ range . }}
+      <li><a href="{{ .url }}">{{ .name }}</a></li>
+    {{ end }}
+  </ul>
+</div>
+{{ end }}

--- a/layouts/research/single.html
+++ b/layouts/research/single.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+<div class="container mt-3">
+  <article>
+    <h1>{{ .Title }}</h1>
+    <div class="content">
+      {{ .Content }}
+    </div>
+
+    <!-- ✅ Related Labs only on research pages -->
+    {{ if eq .Section "research" }}
+      {{ partial "related-labs.html" . }}
+    {{ end }}
+
+  </article>
+</div>
+{{ end }}


### PR DESCRIPTION
layout olarak related-labs section ekledim ve sayfa temasını düzenlemek için layout/research/single.html ekledim, linkleri şu an için yalnızca ingilizce artificial intelligence sayfası için ekledim. Structure için gelecek feedbacklere göre düzenleme yapabilirim veya diğer sayfalara ilgili labları eklemeye devam edebilirim 