### PR TITLE
Fix broken Graduate Programs link

### DIFF
--- a/config/_default/footer.en.yml
+++ b/config/_default/footer.en.yml
@@ -100,7 +100,7 @@ menu:
       parent: graduate-footer
       weight: 302
     - name: Other Affiliated Programs
-      url: /graduate/other-programs
+      url: /graduate/affiliated-programs
       identifier: graduate-affiliated-footer
       parent: graduate-footer
       weight: 303

--- a/config/_default/footer.tr.yml
+++ b/config/_default/footer.tr.yml
@@ -100,7 +100,7 @@ menu:
       parent: graduate-footer
       weight: 302
     - name: Diğer İlişkili Programlar
-      url: /graduate/other-programs
+      url: /graduate/affiliated-programs
       identifier: graduate-affiliated-footer
       parent: graduate-footer
       weight: 303


### PR DESCRIPTION
The link for Graduate Programs Other Programs was pointing to an outdated URL.

- Old URL: https://cmpe.bogazici.edu.tr/graduate/other-programs  
  This returned a 404 – Page not found.  
- New URL: https://cmpe.bogazici.edu.tr/graduate/affiliated-programs/  

### Change
Replaced the broken URL with the correct one so users are redirected properly.