### PR TITLE
Fix relative paths in issue_to_md.py

### DIFF
--- a/.github/issue-to-md/scripts/issue_to_md.py
+++ b/.github/issue-to-md/scripts/issue_to_md.py
@@ -13,8 +13,8 @@ from jinja2 import Environment, FileSystemLoader
 GITHUB_REPOSITORY = os.getenv("GITHUB_REPOSITORY")
 ISSUE_NUMBER      = int(os.getenv("ISSUE_NUMBER", "0"))
 GITHUB_TOKEN      = os.getenv("GITHUB_TOKEN")
-UPLOADS_DIR       = Path("assets/uploads")
-CONTENT_DIR       = Path("content")
+UPLOADS_DIR       = Path("../../assets/uploads")
+CONTENT_DIR       = Path("../../content")
 DEBUG             = True
 
 if not GITHUB_REPOSITORY or not GITHUB_TOKEN or ISSUE_NUMBER == 0:

--- a/.github/issue-to-md/scripts/issue_to_md.py
+++ b/.github/issue-to-md/scripts/issue_to_md.py
@@ -8,16 +8,23 @@ from uuid import uuid4
 from pathlib import Path
 from github import Github
 from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+def project_root() -> Path:
+    env_root = os.getenv("PROJECT_ROOT")
+    return Path(env_root).resolve() if env_root else Path(__file__).resolve().parents[2]
 
 # ─── CONFIGURATION ─────────────────────────────────────────────────────────────
 GITHUB_REPOSITORY = os.getenv("GITHUB_REPOSITORY")
 ISSUE_NUMBER      = int(os.getenv("ISSUE_NUMBER", "0"))
 GITHUB_TOKEN      = os.getenv("GITHUB_TOKEN")
-UPLOADS_DIR       = Path("../../assets/uploads")
-CONTENT_DIR       = Path("../../content")
+
+ROOT = project_root()
+UPLOADS_DIR = ROOT / "assets" / "uploads"
+CONTENT_DIR = ROOT / "content"
 DEBUG             = True
 
-if not GITHUB_REPOSITORY or not GITHUB_TOKEN or ISSUE_NUMBER == 0:
+if not GITHUB_REPOSITORY or not GITHUB_TOKEN or not ROOT or ISSUE_NUMBER == 0:
     missing = [n for n in ["GITHUB_REPOSITORY","GITHUB_TOKEN","ISSUE_NUMBER"] if not os.getenv(n)]
     raise RuntimeError(f"Missing required env vars: {', '.join(missing)}")
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -16,6 +16,8 @@ jobs:
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PROJECT_ROOT: ${{ github.workspace }}   
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
While testing the issue-to-md feature and preparing the tutorial, I noticed that the output content was being written to the wrong folder. This happened because the source files were moved under the `.github/issue-to-md` namespace and set as the working directory, while the script relied on relative paths.

This pull request fixes that bug by introducing a `PROJECT_ROOT` environment variable and resolving content and asset paths relative to the repository root. This makes the script robust against changes in directory layout.