### PR TITLE
Add CMPE-specific training information for current students in English and Turkish

### DIFF
--- a/content/undergraduate/training.en.md
+++ b/content/undergraduate/training.en.md
@@ -59,7 +59,7 @@ organizations.
 ## For Current CMPE Students
 
 If you are a current CMPE student, please use the
-[CMPE INTERN website](https://intern.cmpe.boun.edu.tr/) to find CMPE-specific
+[**CMPE INTERN website**](https://intern.cmpe.boun.edu.tr/) to find CMPE-specific
 rules and information about the training requirement, manage your internship
 process, and learn where to direct further questions.
 

--- a/content/undergraduate/training.en.md
+++ b/content/undergraduate/training.en.md
@@ -56,6 +56,13 @@ organizations.
    at the work place evaluates the trainee. This form must be signed by the
    supervisor and handed to the student in a closed and stamped envelope.
 
+## For Current CMPE Students
+
+If you are a current CMPE student, please use the
+[CMPE INTERN website](https://intern.cmpe.boun.edu.tr/) to find CMPE-specific
+rules and information about the training requirement, manage your internship
+process, and learn where to direct further questions.
+
 ## Training Coordinator
 
 {{< people tag="training" cols="1" >}}

--- a/content/undergraduate/training.tr.md
+++ b/content/undergraduate/training.tr.md
@@ -27,7 +27,7 @@ weight: 7
 
 ## Mevcut CMPE Öğrencileri İçin
 
-CMPE öğrencisiyseniz, staj yükümlülüğüyle ilgili CMPE'ye özgü kurallar hakkında bilgi almak ve staj sürecinizi yürütmek için lütfen [CMPE INTERN web sitesini](https://intern.cmpe.boun.edu.tr/) kullanın. Ek sorularınızı nereye yönelteceğinize ilişkin bilgilendirmeler de yine bu sitede yer almaktadır.
+CMPE öğrencisiyseniz, staj yükümlülüğüyle ilgili CMPE'ye özgü kurallar hakkında bilgi almak ve staj sürecinizi yürütmek için lütfen [**CMPE INTERN web sitesini**](https://intern.cmpe.boun.edu.tr/) kullanın. Ek sorularınızı nereye yönelteceğinize ilişkin bilgilendirmeler de yine bu sitede yer almaktadır.
 
 ## Staj Danışmanı
 

--- a/content/undergraduate/training.tr.md
+++ b/content/undergraduate/training.tr.md
@@ -25,6 +25,10 @@ weight: 7
    - Değerlendirme Yazısı: Öğrencinin yapılan stajın eğitimine katkısını ve çalışılan işyerinin şartlarını kısa biryazıyla değerlendirdiği bölüm.
 2. **Staj Sicili**: Çalışılan işyerindeki amirinin staj yapan oğrenciyi değerlendirdiği bir formdur. Bu form amir tarafından doldurulduktan sonra imzalanıp kapalı ve mühürlü bir zarf içerisinde öğrenciye verilir.
 
+## Mevcut CMPE Öğrencileri İçin
+
+CMPE öğrencisiyseniz, staj yükümlülüğüyle ilgili CMPE'ye özgü kurallar hakkında bilgi almak ve staj sürecinizi yürütmek için lütfen [CMPE INTERN web sitesini](https://intern.cmpe.boun.edu.tr/) kullanın. Ek sorularınızı nereye yönelteceğinize ilişkin bilgilendirmeler de yine bu sitede yer almaktadır.
+
 ## Staj Danışmanı
 
 {{< people tag="training" cols="1" >}}


### PR DESCRIPTION
Sadece Industrial Training sayfasında değişiklik var, sadece 1-2 cümlelik bir yeni section ekleniyor. Ancak şunu vurgulamalıyım: O section'da CMPE INTERN sitesine (https://intern.cmpe.boun.edu.tr/) link veriliyor; zaten değişikliğin esas amacı da o. Umarım o siteye link vermemiz sorun değildir çünkü öğrencilerimizi bir şekilde resmi olarak o siteye yönlendirmeliyiz, tüm staj işleri o site üzerinden yönetiliyor, tüm bilgiler orada, buradakilerin hepsi sadece "mühendislik fakültesi için genel bilgiler".

Cloudflare Pages linkleri çok zor açılıyor. Fatih Hoca'da açılmadı, ben kendisine ekran görüntüsünü attım, değişikliğe onay verdi. Mesajını aşağıda alıntılıyorum:

> Utkan selam
> bende de acilmadi, ama text kısmları OK,  eline saglik, 
> selamlar
> FA

Hatta ilgili mesaj zincirini de PDF olarak iliştiriyorum: [fatih-hoca-onay.pdf](https://github.com/user-attachments/files/27233236/fatih-hoca-onay.pdf)


Closes #208